### PR TITLE
add rfkill dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.5
 
 Package: blueberry
 Architecture: all
-Depends: python (>= 2.4), python (<< 3), gnome-bluetooth, gir1.2-gnomebluetooth-1.0, wmctrl
+Depends: python (>= 2.4), python (<< 3), gnome-bluetooth, gir1.2-gnomebluetooth-1.0, rfkill, wmctrl
 Breaks: cinnamon-bluetooth
 Replaces: cinnamon-bluetooth
 Description: A configuration tool for Bluetooth


### PR DESCRIPTION
...since no runtime check for it is done