### PR TITLE
Fix monitoring settings

### DIFF
--- a/usr/lib/blueberry/blueberry-tray.py
+++ b/usr/lib/blueberry/blueberry-tray.py
@@ -25,6 +25,7 @@ class BluetoothTray:
             sys.exit(0)
 
         self.settings.gsettings.connect("changed::tray-enabled", self.on_settings_changed_cb)
+        self.settings.get_tray_enabled()
 
         self.client = GnomeBluetooth.Client()
         self.model = self.client.get_model()


### PR DESCRIPTION
We have to read settings once, otherwise changes are not detected.