### PR TITLE
Hide in GNOME, KDE and Unity

### DIFF
--- a/etc/xdg/autostart/blueberry-tray.desktop
+++ b/etc/xdg/autostart/blueberry-tray.desktop
@@ -8,4 +8,4 @@ Type=Application
 Categories=GTK;GNOME;Settings;X-GNOME-NetworkSettings;
 StartupNotify=false
 NoDisplay=true
-NotShowIn=GNOME;KDE;
+NotShowIn=GNOME;KDE;Unity;

--- a/etc/xdg/autostart/blueberry-tray.desktop
+++ b/etc/xdg/autostart/blueberry-tray.desktop
@@ -8,4 +8,4 @@ Type=Application
 Categories=GTK;GNOME;Settings;X-GNOME-NetworkSettings;
 StartupNotify=false
 NoDisplay=true
-
+NotShowIn=GNOME;KDE;

--- a/usr/share/applications/blueberry.desktop
+++ b/usr/share/applications/blueberry.desktop
@@ -127,3 +127,4 @@ Terminal=false
 Type=Application
 Categories=GTK;GNOME;Settings;HardwareSettings;X-XFCE-SettingsDialog;X-XFCE-HardwareSettings;
 StartupNotify=true
+NotShowIn=GNOME;KDE;

--- a/usr/share/applications/blueberry.desktop
+++ b/usr/share/applications/blueberry.desktop
@@ -127,4 +127,4 @@ Terminal=false
 Type=Application
 Categories=GTK;GNOME;Settings;HardwareSettings;X-XFCE-SettingsDialog;X-XFCE-HardwareSettings;
 StartupNotify=true
-NotShowIn=GNOME;KDE;
+NotShowIn=GNOME;KDE;Unity;


### PR DESCRIPTION
GNOME and KDE have their own interfaces to handle Bluetooth devices.