### PR TITLE
Fix deprecation

### DIFF
--- a/usr/lib/blueberry/blueberrySettings.py
+++ b/usr/lib/blueberry/blueberrySettings.py
@@ -7,7 +7,7 @@ TRAY_KEY = "tray-enabled"
 
 class Settings():
     def __init__(self):
-        self.gsettings = Gio.Settings(SETTINGS_SCHEMA)
+        self.gsettings = Gio.Settings.new(SETTINGS_SCHEMA)
 
     def get_tray_enabled(self):
         return self.gsettings.get_boolean(TRAY_KEY)


### PR DESCRIPTION
This eliminates the following message on start:
"Warning: The property GSettings:schema is deprecated and shouldn't be used anymore. It will be removed in a future version."