### PR TITLE
Fix how autostart of the tray icon is handled

### DIFF
--- a/etc/xdg/autostart/blueberry-tray.desktop
+++ b/etc/xdg/autostart/blueberry-tray.desktop
@@ -3,6 +3,7 @@
 Name=blueberry
 Comment=Blueberry tray icon
 Exec=blueberry-tray
+AutostartCondition=GSettings org.blueberry tray-enabled
 Terminal=false
 Type=Application
 Categories=GTK;GNOME;Settings;X-GNOME-NetworkSettings;

--- a/usr/lib/blueberry/blueberry.py
+++ b/usr/lib/blueberry/blueberry.py
@@ -169,9 +169,7 @@ class Blueberry(Gtk.Application):
         self.tray_switch.set_active(self.settings.get_boolean("tray-enabled"))
         self.tray_switch.connect("notify::active", self.on_tray_switch_toggled)
         self.settings.connect("changed", self.on_settings_changed)
-        if self.de != "Cinnamon":
-            # In Cinnamon we're using an applet instead
-            section.add_row(SettingsRow(Gtk.Label(_("Show a tray icon")), self.tray_switch))
+        section.add_row(SettingsRow(Gtk.Label(_("Show a tray icon")), self.tray_switch))
 
         self.window.add(self.main_box)
 


### PR DESCRIPTION
Don't autostart blueberry-tray if the "tray-enabled" key is set to false. In
addition show this switch in Cinnamon as well.