### PR TITLE
rfkillMagic: Use a child wrapper for the monitor subprocess.

### DIFF
--- a/usr/lib/blueberry/blueberry-tray.py
+++ b/usr/lib/blueberry/blueberry-tray.py
@@ -19,10 +19,6 @@ class BluetoothTray(Gtk.Application):
     def do_activate(self):
         self.hold()
 
-    def do_shutdown(self):
-        self.terminate()
-        Gtk.Application.do_shutdown(self)
-
     def do_startup(self):
         Gtk.Application.do_startup(self)
 
@@ -142,8 +138,7 @@ class BluetoothTray(Gtk.Application):
         subprocess.Popen(["blueberry"])
 
     def terminate(self, window = None, data = None):
-        self.rfkill.terminate()
-        self.release()
+        self.quit()
 
 if __name__ == "__main__":
     BluetoothTray().run()

--- a/usr/lib/blueberry/blueberry.py
+++ b/usr/lib/blueberry/blueberry.py
@@ -75,7 +75,6 @@ class Blueberry(Gtk.Application):
 
         self.window.set_title(_("Bluetooth"))
         self.window.set_icon_name("bluetooth")
-        self.window.connect("destroy", self.terminate)
         self.window.set_default_size(640, 400)
 
         self.main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -296,9 +295,6 @@ class Blueberry(Gtk.Application):
     def on_switch_changed(self, widget, state):
         self.rfkill.try_set_blocked(not state)
         return True
-
-    def terminate(self, window):
-        self.rfkill.terminate()
 
 if __name__ == "__main__":
     app = Blueberry()

--- a/usr/lib/blueberry/rfkillMagic.py
+++ b/usr/lib/blueberry/rfkillMagic.py
@@ -8,7 +8,7 @@ RFKILL_CHK = ["/usr/sbin/rfkill", "list", "bluetooth"]
 RFKILL_BLOCK = ["/usr/sbin/rfkill", "block", "bluetooth"]
 RFKILL_UNBLOCK = ["/usr/sbin/rfkill", "unblock", "bluetooth"]
 
-RFKILL_EVENT_MONITOR = ["/usr/sbin/rfkill", "event"]
+RFKILL_EVENT_MONITOR = ["/usr/lib/blueberry/safechild", "/usr/sbin/rfkill", "event"]
 
 # index of .split() from rfkill event output where lines are:
 #     1426095957.906704: idx 0 type 1 op 0 soft 0 hard 0
@@ -75,7 +75,7 @@ class Interface:
             thread.start_new_thread(self.event_monitor_thread, (None,))
 
     def event_monitor_thread(self, data):
-        self.tproc = subprocess.Popen(RFKILL_EVENT_MONITOR, stdout=subprocess.PIPE)
+        self.tproc = subprocess.Popen(RFKILL_EVENT_MONITOR, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
         while self.tproc.poll() is None and not self.monitor_killer:
             l = self.tproc.stdout.readline() # This blocks until it receives a newline.
             self.update_state(l)
@@ -121,8 +121,6 @@ class Interface:
         thread.exit()
 
     def terminate(self):
-        if self.tproc:
-            self.tproc.kill()
         if self.blockproc:
             self.blockproc.kill()
 

--- a/usr/lib/blueberry/safechild
+++ b/usr/lib/blueberry/safechild
@@ -1,0 +1,35 @@
+#!/usr/bin/env python2
+
+import subprocess
+import sys
+
+"""
+Wrapper for rfkill binary.
+
+This script spawns a process, then monitors stdin of its own parent
+and terminates the child when an EOF is received from the parent.
+
+This will happen when safechild's parent exits and its
+pipes are closed, regardless of *how* it got terminated.
+
+This script must be spawned by its parent with a STDIN pipe.  The pipe
+never actually needs to be used or access (in fact it's probably safer
+if it *isn't* accessed, since unless you're careful, garbage collection
+may cause an EOF to be sent, causing early termination of this script
+and its child.)
+
+"""
+
+proc = None
+
+try:
+    proc = subprocess.Popen(sys.argv[1:])
+
+    while True:
+        line = sys.stdin.readline()
+        if line == "":
+            proc.kill()
+            proc.wait()
+            break
+except Exception as e:
+    print "safechild exception: ", e


### PR DESCRIPTION
This ensures we don't end up with orphan processes regardless of how the tray is terminated.

Use Gio.Application.quit() for exiting the tray from its menu entry, as it ignores the application
use count (caused by previous commit adding an app id), and exits the process no matter how many
times it has  been called.
