### PR TITLE
Fix PyGIDeprecationWarnings

### DIFF
--- a/usr/lib/blueberry/blueberry.py
+++ b/usr/lib/blueberry/blueberry.py
@@ -23,7 +23,7 @@ class Blueberry(Gtk.Application):
     def __init__(self):
 
         Gtk.Application.__init__(self, application_id='com.linuxmint.blueberry', flags=Gio.ApplicationFlags.FLAGS_NONE)
-        self.window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+        self.window = Gtk.Window(type=Gtk.WindowType.TOPLEVEL)
         self.detect_desktop_environment()
         self.connect("activate", self.on_activate)
 

--- a/usr/lib/blueberry/blueberry.py
+++ b/usr/lib/blueberry/blueberry.py
@@ -103,7 +103,7 @@ class Blueberry(Gtk.Application):
         stack_switcher.set_halign(Gtk.Align.CENTER)
         toolbar.show_all()
 
-        self.settings = Gio.Settings("org.blueberry")
+        self.settings = Gio.Settings(schema="org.blueberry")
 
         debug = False
         if len(sys.argv) > 1 and sys.argv[1] == "debug":
@@ -162,7 +162,7 @@ class Blueberry(Gtk.Application):
         self.obex_switch.set_active(self.settings.get_boolean("obex-enabled"))
         self.obex_switch.connect("notify::active", self.on_obex_switch_toggled)
         self.settings.connect("changed", self.on_settings_changed)
-        row = SettingsRow(Gtk.Label(_("Receive files from remote devices")), self.obex_switch)
+        row = SettingsRow(Gtk.Label(label=_("Receive files from remote devices")), self.obex_switch)
         row.set_tooltip_text(_("This option allows your computer to receive files transferred over Bluetooth (OBEX)"))
         section.add_row(row)
 
@@ -170,7 +170,7 @@ class Blueberry(Gtk.Application):
         self.tray_switch.set_active(self.settings.get_boolean("tray-enabled"))
         self.tray_switch.connect("notify::active", self.on_tray_switch_toggled)
         self.settings.connect("changed", self.on_settings_changed)
-        section.add_row(SettingsRow(Gtk.Label(_("Show a tray icon")), self.tray_switch))
+        section.add_row(SettingsRow(Gtk.Label(label=_("Show a tray icon")), self.tray_switch))
 
         self.window.add(self.main_box)
 
@@ -221,7 +221,7 @@ class Blueberry(Gtk.Application):
         self.obex_switch.set_active(self.settings.get_boolean("obex-enabled"))
 
     def add_stack_page(self, message, name):
-        label = Gtk.Label(message)
+        label = Gtk.Label(label=message)
         self.stack.add_named(label, name)
         label.show()
 

--- a/usr/lib/blueberry/rfkillMagic.py
+++ b/usr/lib/blueberry/rfkillMagic.py
@@ -3,7 +3,7 @@ import thread
 import subprocess
 import os
 import re
-from gi.repository import GObject
+from gi.repository import GLib
 
 RFKILL_CHK = ["/usr/sbin/rfkill", "list", "bluetooth"]
 RFKILL_BLOCK = ["/usr/sbin/rfkill", "block", "bluetooth"]
@@ -108,7 +108,7 @@ class Interface:
         self.update_ui()
 
     def update_ui(self):
-        GObject.idle_add(self.output_callback)
+        GLib.idle_add(self.output_callback)
 
     def try_set_blocked(self, blocked):
         thread.start_new_thread(self.set_block_thread, (blocked,))


### PR DESCRIPTION
Running `blueberry` currently raises some deprecation warnings when the latest `pygobject` module is installed:

```
/usr/lib/blueberry/blueberry.py:26: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "type" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self.window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
/usr/lib/blueberry/blueberry.py:106: PyGIDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "schema" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self.settings = Gio.Settings("org.blueberry")
/usr/lib/blueberry/blueberry.py:224: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  label = Gtk.Label(message)
/usr/lib/blueberry/rfkillMagic.py:111: PyGIDeprecationWarning: GObject.idle_add is deprecated; use GLib.idle_add instead
  GObject.idle_add(self.output_callback)
/usr/lib/blueberry/BlueberrySettingsWidgets.py:35: PyGTKDeprecationWarning: Initializer is relying on deprecated non-standard defaults. Please update to explicitly use: mode=<enum GTK_SIZE_GROUP_VERTICAL of type Gtk.SizeGroupMode> See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self.size_group = Gtk.SizeGroup()
/usr/lib/blueberry/blueberry.py:157: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  row = SettingsRow(Gtk.Label(_("Name")), self.adapter_name_entry)
/usr/lib/blueberry/blueberry.py:165: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  row = SettingsRow(Gtk.Label(_("Receive files from remote devices")), self.obex_switch)
/usr/lib/blueberry/blueberry.py:173: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  section.add_row(SettingsRow(Gtk.Label(_("Show a tray icon")), self.tray_switch))
```

The given PR performs the changes proposed by the deprecation warnings. (I only left out the one in `/usr/lib/blueberry/BlueberrySettingsWidgets.py:35` as I do not know what should be the right thing to do there.)