### PR TITLE
Remove unused applet label

### DIFF
--- a/usr/share/cinnamon/applets/blueberry@cinnamon.org/applet.js
+++ b/usr/share/cinnamon/applets/blueberry@cinnamon.org/applet.js
@@ -22,10 +22,10 @@ function MyApplet(metadata, orientation, panel_height, instance_id) {
 }
 
 MyApplet.prototype = {
-    __proto__: Applet.TextIconApplet.prototype,
+    __proto__: Applet.IconApplet.prototype,
 
     _init: function(metadata, orientation, panel_height, instance_id) {
-        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
 
         this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
@@ -51,8 +51,6 @@ MyApplet.prototype = {
             }));
             this.menu.addMenuItem(item);
 
-            this.on_orientation_changed(orientation);
-
             this._client = new GnomeBluetooth.Client();
             this._model = this._client.get_model();
             this._model.connect('row-changed', Lang.bind(this, this._sync));
@@ -71,13 +69,6 @@ MyApplet.prototype = {
 
     on_applet_removed_from_panel: function() {
         Main.systrayManager.unregisterId(this.metadata.uuid);
-    },
-
-    on_orientation_changed: function(orientation) {
-        if (orientation == St.Side.LEFT || orientation == St.Side.RIGHT)
-            this.hide_applet_label(true);
-        else
-            this.hide_applet_label(false);
     },
 
     _getDefaultAdapter: function() {

--- a/usr/share/cinnamon/applets/blueberry@cinnamon.org/metadata.json
+++ b/usr/share/cinnamon/applets/blueberry@cinnamon.org/metadata.json
@@ -3,5 +3,5 @@
     "description": "Blueberry applet", 
     "uuid": "blueberry@cinnamon.org", 
     "name": "Bluetooth", 
-    "last-edited": "1355436562"
+    "last-edited": "1517395944"
 }


### PR DESCRIPTION
Inherit from IconApplet instead of TextIconApplet because the label
wasn't being used. It caused an issue where the label was taking up
space even when it was empty when using padding or margins on it.

A visual example:
![screenshot from 2018-01-31 12-10-47](https://user-images.githubusercontent.com/10391266/35620053-26f0eb00-0680-11e8-9eee-0cd9650a2891.png)
