### PR TITLE
Fix PyGIDeprecationWarning

### DIFF
--- a/usr/lib/blueberry/blueberry-tray.py
+++ b/usr/lib/blueberry/blueberry-tray.py
@@ -27,7 +27,7 @@ class BluetoothTray(Gtk.Application):
             debug = True
 
         self.rfkill = rfkillMagic.Interface(self.update_icon_callback, debug)
-        self.settings = Gio.Settings("org.blueberry")
+        self.settings = Gio.Settings(schema="org.blueberry")
         self.settings.connect("changed::tray-enabled", self.on_settings_changed_cb)
 
         # If we have no adapter, or disabled tray, end early


### PR DESCRIPTION
Fixes this warning

```
/usr/lib/blueberry/blueberry-tray.py:30: PyGIDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "schema" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self.settings = Gio.Settings("org.blueberry")
```