### PR TITLE
spinner workaround

### DIFF
--- a/usr/lib/blueberry/blueberry.py
+++ b/usr/lib/blueberry/blueberry.py
@@ -254,6 +254,9 @@ class Blueberry(Gtk.Application):
             scrolledwindow.set_shadow_type(Gtk.ShadowType.NONE)
             viewport = scrolledwindow.get_children()[0]
             vbox = viewport.get_children()[0]
+            spinner = vbox.get_children()[1].get_children()[0].get_children()[1]
+            if spinner.props.active:
+                spinner.stop()
             explanation_label = vbox.get_children()[0]
             name = self.get_default_adapter_name()
             if name is not None:


### PR DESCRIPTION
I've tracked the issue described in #55 and found it happens when the spinner is rendered and this could be a GTK bug (there are some bug reports about spinners CPU usage).

I've added a couple of lines of code to stop the spinner instance as a workaround and it works, but the user has no feedback on the scanning process...