### PR TITLE
fix tray icon not shown with window

### DIFF
--- a/usr/lib/blueberry/blueberry.py
+++ b/usr/lib/blueberry/blueberry.py
@@ -38,6 +38,9 @@ class Blueberry(Gtk.Application):
             self.get_active_window().present()
         else:
             self.create_window()
+        # In either case, show tray icon if enabled in Settings
+        if self.settings.get_boolean("tray-enabled"):
+            subprocess.Popen(['blueberry-tray'])
 
     def detect_desktop_environment(self):
         wm_info = subprocess.getoutput("wmctrl -m")


### PR DESCRIPTION
**Fixes** #86 

We currently do not check if tray icon needs to be shown or not.

I have added a `if` condition which checks for `tray-enabled` flag in `on_activate` function of `blueberry.py` and uses `subprocess.Popen` to start `blueberry-tray.py` 