### PR TITLE
Ui rework / hotplugging fixups

### DIFF
--- a/usr/lib/blueberry/BlueberrySettingsWidgets.py
+++ b/usr/lib/blueberry/BlueberrySettingsWidgets.py
@@ -8,56 +8,38 @@ def list_header_func(row, before, user_data):
     if before and not row.get_header():
         row.set_header(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
 
-class SettingsPage(Gtk.Box):
-
-    def __init__(self):
-        Gtk.Box.__init__(self)
-        self.set_orientation(Gtk.Orientation.VERTICAL)
-        self.set_spacing(15)
-        self.set_margin_left(80)
-        self.set_margin_right(80)
-        self.set_margin_top(15)
-        self.set_margin_bottom(15)
-
-    def add_section(self, title):
-        section = SettingsBox(title)
-        self.pack_start(section, False, False, 0)
-
-        return section
-
 class SettingsBox(Gtk.Frame):
 
-    def __init__(self, title):
+    def __init__(self, title=""):
         Gtk.Frame.__init__(self)
         self.set_shadow_type(Gtk.ShadowType.IN)
         frame_style = self.get_style_context()
         frame_style.add_class("view")
-        self.size_group = Gtk.SizeGroup()
-        self.size_group.set_mode(Gtk.SizeGroupMode.VERTICAL)
 
         self.box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.add(self.box)
 
-        toolbar = Gtk.Toolbar.new()
-        toolbar_context = toolbar.get_style_context()
-        Gtk.StyleContext.add_class(Gtk.Widget.get_style_context(toolbar), "cs-header")
+        if title != "":
+            toolbar = Gtk.Toolbar.new()
+            toolbar_context = toolbar.get_style_context()
+            Gtk.StyleContext.add_class(Gtk.Widget.get_style_context(toolbar), "cs-header")
 
-        label = Gtk.Label.new()
-        label.set_markup("<b>%s</b>" % title)
-        title_holder = Gtk.ToolItem()
-        title_holder.add(label)
-        toolbar.add(title_holder)
-        self.box.add(toolbar)
+            label = Gtk.Label.new()
+            label.set_markup("<b>%s</b>" % title)
+            title_holder = Gtk.ToolItem()
+            title_holder.add(label)
+            toolbar.add(title_holder)
+            self.box.add(toolbar)
 
-        toolbar_separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
-        self.box.add(toolbar_separator)
-        separator_context = toolbar_separator.get_style_context()
-        frame_color = frame_style.get_border_color(Gtk.StateFlags.NORMAL).to_string()
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_data(".separator {{ -GtkWidget-wide-separators: 0; \
-                                                   color: {};                    \
-                                                }}".format(frame_color).encode())
-        separator_context.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+            toolbar_separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
+            self.box.add(toolbar_separator)
+            separator_context = toolbar_separator.get_style_context()
+            frame_color = frame_style.get_border_color(Gtk.StateFlags.NORMAL).to_string()
+            css_provider = Gtk.CssProvider()
+            css_provider.load_from_data(".separator {{ -GtkWidget-wide-separators: 0; \
+                                                    color: {};                    \
+                                                    }}".format(frame_color).encode())
+            separator_context.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
         self.list_box = Gtk.ListBox()
         self.list_box.set_selection_mode(Gtk.SelectionMode.NONE)

--- a/usr/lib/blueberry/BlueberrySettingsWidgets.py
+++ b/usr/lib/blueberry/BlueberrySettingsWidgets.py
@@ -21,7 +21,6 @@ class SettingsBox(Gtk.Frame):
 
         if title != "":
             toolbar = Gtk.Toolbar.new()
-            toolbar_context = toolbar.get_style_context()
             Gtk.StyleContext.add_class(Gtk.Widget.get_style_context(toolbar), "cs-header")
 
             label = Gtk.Label.new()

--- a/usr/lib/blueberry/blueberry.py
+++ b/usr/lib/blueberry/blueberry.py
@@ -166,7 +166,6 @@ class Blueberry(Gtk.Application):
         self.lib_widget = GnomeBluetooth.SettingsWidget.new()
         self.lib_widget.connect("panel-changed", self.panel_changed)
         builder.get_object("bluetooth-widget-box").pack_start(self.lib_widget, True, True, 0)
-        self.lib_widget.show()
 
         # Settings
         settings_box = SettingsBox()
@@ -196,11 +195,8 @@ class Blueberry(Gtk.Application):
         self.settings.connect("changed", self.on_settings_changed)
         settings_box.add_row(SettingsRow(Gtk.Label(label=_("Show a tray icon")), self.tray_switch))
 
-        settings_container.show_all()
-
         self.add_window(window)
         window.show_all()
-
         self.update_ui_callback()
 
         # attempt to apply overrides and if we fail don't setup update hooks
@@ -212,7 +208,6 @@ class Blueberry(Gtk.Application):
             self.model.connect('row-changed', self.update_status)
             self.model.connect('row-deleted', self.update_status)
             self.model.connect('row-inserted', self.update_status)
-            self.update_status()
 
     def panel_changed(self, widget, panel):
         if not panel in self.configuration_tools:

--- a/usr/lib/blueberry/blueberry.py
+++ b/usr/lib/blueberry/blueberry.py
@@ -243,7 +243,11 @@ class Blueberry(Gtk.Application):
         self.obex_switch.set_active(self.settings.get_boolean("obex-enabled"))
 
     def get_default_adapter_name(self):
+        if not self.rfkill.have_adapter:
+            return None
+
         name = None
+
         try:
             output = subprocess.check_output(["timeout", "2s", "bt-adapter", "-i"]).decode("utf-8").strip()
             for line in output.split("\n"):
@@ -253,6 +257,7 @@ class Blueberry(Gtk.Application):
                     break
         except Exception as cause:
             log("Could not retrieve the BT adapter name with 'bt-adapter -i': {}".format(cause))
+
         return name
 
     def update_status(self, path=None, iter=None, data=None):

--- a/usr/lib/blueberry/blueberry.ui
+++ b/usr/lib/blueberry/blueberry.ui
@@ -31,7 +31,7 @@
       <object class="GtkHeaderBar">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="title" translatable="yes">Blueberry</property>
+        <property name="title">Blueberry</property>
         <property name="show_close_button">True</property>
         <child>
           <object class="GtkImage" id="header-icon">
@@ -52,6 +52,7 @@
         </child>
         <child>
           <object class="GtkImage" id="rfkill-error-image">
+            <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="icon_name">dialog-error</property>
             <property name="icon_size">3</property>
@@ -134,7 +135,7 @@
                   <object class="GtkLabel" id="status-label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">"No Bluetooth adapters found" in some language that has an extremely verbose way of saying it might look something like this</property>
+                    <property name="label">status label</property>
                     <property name="justify">center</property>
                     <property name="wrap">True</property>
                   </object>

--- a/usr/lib/blueberry/blueberry.ui
+++ b/usr/lib/blueberry/blueberry.ui
@@ -51,6 +51,16 @@
           </packing>
         </child>
         <child>
+          <object class="GtkImage" id="rfkill-error-image">
+            <property name="can_focus">False</property>
+            <property name="icon_name">dialog-error</property>
+            <property name="icon_size">3</property>
+          </object>
+          <packing>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkMenuButton" id="settings-button">
             <property name="visible">True</property>
             <property name="can_focus">True</property>

--- a/usr/lib/blueberry/blueberry.ui
+++ b/usr/lib/blueberry/blueberry.ui
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.16"/>
+  <object class="GtkPopover" id="settings-popover">
+    <property name="can_focus">False</property>
+    <property name="relative_to">settings-button</property>
+    <property name="modal">False</property>
+    <property name="transitions_enabled">False</property>
+    <child>
+      <object class="GtkBox" id="settings-container">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_left">8</property>
+        <property name="margin_right">8</property>
+        <property name="margin_top">8</property>
+        <property name="margin_bottom">8</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkWindow" id="window">
+    <property name="can_focus">False</property>
+    <property name="default_width">640</property>
+    <property name="default_height">400</property>
+    <property name="icon_name">blueberry</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="title" translatable="yes">Blueberry</property>
+        <property name="show_close_button">True</property>
+        <child>
+          <object class="GtkImage" id="header-icon">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="icon_name">blueberry</property>
+            <property name="icon_size">3</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="bluetooth-switch">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+          </object>
+          <packing>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkMenuButton" id="settings-button">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="direction">none</property>
+            <property name="popover">settings-popover</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkStack" id="stack">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_left">8</property>
+        <property name="margin_right">8</property>
+        <property name="margin_top">8</property>
+        <property name="margin_bottom">8</property>
+        <child>
+          <object class="GtkBox" id="bluetooth-widget-box">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="name">main-page</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">16</property>
+            <property name="margin_right">16</property>
+            <property name="margin_top">16</property>
+            <property name="margin_bottom">16</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child type="center">
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
+                <child>
+                  <object class="GtkImage" id="status-icon">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">dialog-info</property>
+                    <property name="icon_size">6</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="status-label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">"No Bluetooth adapters found" in some language that has an extremely verbose way of saying it might look something like this</property>
+                    <property name="justify">center</property>
+                    <property name="wrap">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="name">status-page</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/usr/lib/blueberry/rfkillMagic.py
+++ b/usr/lib/blueberry/rfkillMagic.py
@@ -31,6 +31,7 @@ class Interface:
 
     def adapter_check(self):
         res = subprocess.check_output(RFKILL_CHK).decode('utf-8')
+        match = None
         have_adapter = False
 
         '''
@@ -44,16 +45,14 @@ class Interface:
             Soft blocked: yes
             Hard blocked: no
         '''
-
         if res:
+            match = re.search(r'^(?P<idx>\d+): .+: Bluetooth\n', res)
+
+        if match:
             self.debug("adapter_check full output:\n%s" % res)
-            reslines = res.split('\n')
-            for line in reslines:
-                if "Bluetooth" in line:
-                    self.adapter_index = int(line[0])
-                    self.debug("adapter_check found adapter at %d" % self.adapter_index)
-                    have_adapter = True
-                    break
+            self.adapter_index = int(match.group('idx'))
+            self.debug("adapter_check found adapter at %d" % self.adapter_index)
+            have_adapter = True
         else:
             self.debug("adapter_check no output (no adapter)")
 


### PR DESCRIPTION
Note: Hardware RF switch untested. I expect it works as usual though, it should show a page identical to bluetooth disabled in the screenshot below except with the additional "by hardware switch" text.

**UI cleanup:**
- Reworks UI to have less wasted space by moving everything into a header bar except the bluetooth widget and status page.
- Static UI layout done with glade/gtkbuilder.

**gnome-bluetooth BluetoothSettingsWidget override fix:**
Widget override code now loops through widgets to find them instead of using a hardcoded "path". It's still fragile. Adding version-specific code is probably the best approach if it breaks again.

**Better support for hotpluggable devices:**
- Always looks for an adapter instead of only starting if we have an adapter and stopping once when we lose it.
- Supports first device index being above 9, which can happen easily with a single hotpluggable device(USB)
- "No adapters" status page now uses dialog-info icon

**Better rfkill error state presentation:**
Previously, when the user did not have permission to /dev/rfkill, the main status page was used to show an error state with a bluetooth disabled icon and the switch set to off and insensitive. This would likely be reached most often by a user attempting to disable bluetooth. This layout may be misleading because it could suggest that bluetooth is disabled when it's actually still enabled and discoverable, and that the application no longer worked because of rfkill permission issues.

The new layout places an rfkill-error-specific image which shows a dialog-error icon next to the toggle switch when an enable/disable operation fails. The error is explained by the image's tooltip which may have low discoverability. A new message was added that explains having a udev rule or being in the rfkill group can fix permissions issues.

This rfkill-specific error state no longer modifies the powered or present states for bluetooth adapter status, which allows the application to work as expected regardless of rfkill permissions.


![rfkill-error](https://user-images.githubusercontent.com/11601860/68056632-dfc23080-fcb0-11e9-97d0-1b4882072370.png)
![Screenshot from 2019-10-31 17-37-17](https://user-images.githubusercontent.com/11601860/68056633-dfc23080-fcb0-11e9-9ae8-e9c6e7598363.png)
![Screenshot from 2019-10-31 17-37-07](https://user-images.githubusercontent.com/11601860/68056634-e05ac700-fcb0-11e9-8e33-7e3504aee297.png)
![Screenshot from 2019-10-31 17-34-51](https://user-images.githubusercontent.com/11601860/68056635-e05ac700-fcb0-11e9-8eb4-5fe010e114fe.png)
![Screenshot from 2019-10-31 17-34-46](https://user-images.githubusercontent.com/11601860/68056636-e05ac700-fcb0-11e9-9f1c-ce7656100aa7.png)
