### PR TITLE
Handle error from rfkill

### DIFF
--- a/usr/lib/blueberry/rfkillMagic.py
+++ b/usr/lib/blueberry/rfkillMagic.py
@@ -30,7 +30,13 @@ class Interface:
         self.start_event_monitor()
 
     def adapter_check(self):
-        res = subprocess.check_output(RFKILL_CHK).decode('utf-8')
+        proc = subprocess.run(RFKILL_CHK, stdout=subprocess.PIPE)
+        if proc.returncode != 0:
+            self.debug("Error running command: %s." % RFKILL_CHK)
+            res = ""
+        else:
+            res = proc.stdout.decode('utf-8')
+
         match = None
         have_adapter = False
 


### PR DESCRIPTION
Fixes #88

In the case where `/dev/rfkill` does not exist `rfkill` will return
false which triggers a backtrace in blueberry, which may then
trigger a distro's bug reporting tool. This is common on virtual
machines.

Instead handle the error. `res` gets set to an empty string, which
the rest of the funtion interprets and having no adapter. This allows
blueberry to launch with a window saying

"No Bluetooth adapters found"