### PR TITLE
[WIP] Update Menu on Status Update

### DIFF
--- a/usr/lib/blueberry/blueberry-tray.py
+++ b/usr/lib/blueberry/blueberry-tray.py
@@ -5,16 +5,18 @@ import gettext
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('GnomeBluetooth', '1.0')
-gi.require_version('XApp', '1.0')
-from gi.repository import Gtk, Gdk, GnomeBluetooth, Gio, XApp
+gi.require_version('AppIndicator3', '0.1')
+from gi.repository import AppIndicator3, Gtk, Gdk, GnomeBluetooth, Gio
 import rfkillMagic
 import setproctitle
 import subprocess
 
 # i18n
 gettext.install("blueberry", "/usr/share/locale")
+_ = gettext.gettext
 
 setproctitle.setproctitle("blueberry-tray")
+
 
 class BluetoothTray(Gtk.Application):
     def __init__(self):
@@ -53,11 +55,14 @@ class BluetoothTray(Gtk.Application):
         self.model.connect('row-deleted', self.update_icon_callback)
         self.model.connect('row-inserted', self.update_icon_callback)
 
-        self.icon = XApp.StatusIcon()
-        self.icon.set_name("blueberry")
-        self.icon.set_tooltip_text(_("Bluetooth"))
-        self.icon.connect("activate", self.on_statusicon_activated)
-        self.icon.connect("button-release-event", self.on_statusicon_released)
+        self.paired_devices = {}
+
+        self.icon = AppIndicator3.Indicator.new(
+            'BlueBerry',
+            'blueberry',
+            AppIndicator3.IndicatorCategory.SYSTEM_SERVICES
+        )
+        self.icon.set_status(AppIndicator3.IndicatorStatus.ACTIVE)
 
         self.update_icon_callback(None, None, None)
 
@@ -71,21 +76,20 @@ class BluetoothTray(Gtk.Application):
             return
 
         if self.rfkill.hard_block or self.rfkill.soft_block:
-            self.icon.set_icon_name(self.tray_disabled_icon)
-            self.icon.set_tooltip_text(_("Bluetooth is disabled"))
+            self.icon.set_icon_full(self.tray_disabled_icon, '')
         else:
-            self.icon.set_icon_name(self.tray_icon)
+            self.icon.set_icon_full(self.tray_icon, '')
             self.update_connected_state()
+
+        self.icon.set_menu(self.build_menu())
 
     def update_connected_state(self):
         self.get_devices()
 
         if len(self.connected_devices) > 0:
-            self.icon.set_icon_name(self.tray_active_icon)
-            self.icon.set_tooltip_text(_("Bluetooth: Connected to %s") % (", ".join(self.connected_devices)))
+            self.icon.set_icon_full(self.tray_active_icon, '')
         else:
-            self.icon.set_icon_name(self.tray_icon)
-            self.icon.set_tooltip_text(_("Bluetooth"))
+            self.icon.set_icon_full(self.tray_icon, '')
 
     def get_devices(self):
         self.connected_devices = []
@@ -117,58 +121,59 @@ class BluetoothTray(Gtk.Application):
 
                 iter = self.model.iter_next(iter)
 
-    def on_statusicon_activated(self, icon, button, time):
-        if button == Gdk.BUTTON_PRIMARY:
-            subprocess.Popen(["blueberry"])
+    def start_blueberry(self, _ignored):
+        subprocess.Popen(["blueberry"])
 
-    def on_statusicon_released(self, icon, x, y, button, time, position):
-        if button == 3:
-            menu = Gtk.Menu()
+    def build_menu(self):
+        menu = Gtk.Menu()
+        blueberry_exec = Gtk.MenuItem(label=_("BlueBerry"))
+        blueberry_exec.connect("activate", self.start_blueberry)
+        menu.append(blueberry_exec)
 
-            if not self.rfkill.hard_block:
-                if self.rfkill.soft_block:
-                    item = Gtk.MenuItem(label=_("Turn on Bluetooth"))
-                    item.connect("activate", self.turn_on_bluetooth)
-                    menu.append(item)
-                else:
-                    item = Gtk.MenuItem(label=_("Turn off Bluetooth"))
-                    item.connect("activate", self.turn_off_bluetooth)
-                    menu.append(item)
-
-            if not(self.rfkill.hard_block or self.rfkill.soft_block):
-                item = Gtk.MenuItem(label=_("Send files to a device"))
-                item.connect("activate", self.send_files_cb)
+        if not self.rfkill.hard_block:
+            if self.rfkill.soft_block:
+                item = Gtk.MenuItem(label=_("Turn on Bluetooth"))
+                item.connect("activate", self.turn_on_bluetooth)
+                menu.append(item)
+            else:
+                item = Gtk.MenuItem(label=_("Turn off Bluetooth"))
+                item.connect("activate", self.turn_off_bluetooth)
                 menu.append(item)
 
-            item = Gtk.MenuItem(label=_("Open Bluetooth device manager"))
-            item.connect("activate", self.open_manager_cb)
+        if not(self.rfkill.hard_block or self.rfkill.soft_block):
+            item = Gtk.MenuItem(label=_("Send files to a device"))
+            item.connect("activate", self.send_files_cb)
             menu.append(item)
 
-            if len(self.paired_devices) > 0:
-                menu.append(Gtk.SeparatorMenuItem())
-                m_item = Gtk.MenuItem(label=_("Paired devices"))
-                menu.append(m_item)
-                paired_menu = Gtk.Menu()
-                m_item.set_submenu(paired_menu)
-                for device in self.paired_devices:
-                    label = device
-                    item = Gtk.ImageMenuItem(label=label)
-                    if device in self.connected_devices:
-                        image = Gtk.Image.new_from_icon_name("emblem-ok-symbolic", Gtk.IconSize.MENU)
-                        image.set_tooltip_text(_("Connected"))
-                        item.set_always_show_image(True)
-                        item.set_image(image)
-                    item.connect("activate",self.toggle_connect_cb, device)
-                    paired_menu.append(item)
+        item = Gtk.MenuItem(label=_("Open Bluetooth device manager"))
+        item.connect("activate", self.open_manager_cb)
+        menu.append(item)
 
+        if len(self.paired_devices) > 0:
             menu.append(Gtk.SeparatorMenuItem())
+            m_item = Gtk.MenuItem(label=_("Paired devices"))
+            menu.append(m_item)
+            paired_menu = Gtk.Menu()
+            m_item.set_submenu(paired_menu)
+            for device in self.paired_devices:
+                label = device
+                item = Gtk.ImageMenuItem(label=label)
+                if device in self.connected_devices:
+                    image = Gtk.Image.new_from_icon_name("emblem-ok-symbolic", Gtk.IconSize.MENU)
+                    image.set_tooltip_text(_("Connected"))
+                    item.set_always_show_image(True)
+                    item.set_image(image)
+                item.connect("activate",self.toggle_connect_cb, device)
+                paired_menu.append(item)
 
-            item = Gtk.MenuItem(label=_("Quit"))
-            item.connect("activate", self.terminate)
-            menu.append(item)
+        menu.append(Gtk.SeparatorMenuItem())
 
-            menu.show_all()
-            icon.popup_menu(menu, x, y, button, time, position)
+        item = Gtk.MenuItem(label=_("Quit"))
+        item.connect("activate", self.terminate)
+        menu.append(item)
+
+        menu.show_all()
+        return menu
 
     def toggle_connect_cb(self, item, data = None):
         proxy = self.paired_devices[data]


### PR DESCRIPTION
There is a problem in the current `blueberry-tray.py` that the `Turn off Bluetooth` button does not change to `Turn on Bluetooth`
since the menu is only built once and never updated.

This problem is resolved by moving the `set_menu` call into the `update_icon_callback`. With this the menu will always be updated when the Bluetooth status changes.

I also merged the following patch into my branch: [libappindicator-patch](https://github.com/linuxmint/blueberry/issues/120).

This will allow `blueberry-tray` to also run under Wayland.